### PR TITLE
JPackage needed an extra module from the JDK.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ allprojects {
 }
 configure(subprojects) {
     apply plugin: 'java-library'
-    sourceCompatibility = 1.17
+    sourceCompatibility = 17
     compileJava {
         options.incremental = true
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
     api "com.badlogicgames.gdx:gdx-ai:$aiVersion"
     api "com.badlogicgames.ashley:ashley:$ashleyVersion"
-    api 'com.squidpony:squidlib-util:3.0.4'
+    api 'com.squidpony:squidlib-util:3.0.6'
     compileOnly 'org.projectlombok:lombok:1.18.22'
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lwjgl3/build.gradle
+++ b/lwjgl3/build.gradle
@@ -79,6 +79,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
 // you could very easily need more modules than this one.
 // use the lwjgl3:suggestModules task to see which modules may be needed.
         modules.set([
+                'java.desktop',
                 'jdk.unsupported'
         ])
         distDir.set(file(buildDir))


### PR DESCRIPTION
This also updates Gradle (it's a backwards-compatible change, from 7.3.3 to 7.6) and SquidLib (I just released 3.0.6, and not a ton changed so it should be compatible). I think using the Java version syntax `17` is supposed to be "more correct" than `1.17`, but various plugins may require 1.17 or 17 for their configuration.